### PR TITLE
Re-adds a forwarder for Port 80 to the K8s Cluster

### DIFF
--- a/.github/ISSUE-TRIAGE.md
+++ b/.github/ISSUE-TRIAGE.md
@@ -2,7 +2,7 @@ Triaging of issues
 ------------------
 
 Triage provides an important way to contribute to an open source project. It can be difficult to keep up with issues and assess the validity of contributions.
-As a non-maintainer, or a contributor, you can help an open source project by triaging issues. 
+As a non-maintainer, or a contributor, you can help an open source project by triaging issues.
 
 
 ## What is triaging?

--- a/.github/ISSUE_TEMPLATE/enhancement-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-suggestion.md
@@ -10,11 +10,11 @@ assignees: ''
 
 **Feature, tool or process you are suggesting improvement for:**
 
-Describe the features, processes or tools are involved with this improvement. 
+Describe the features, processes or tools are involved with this improvement.
 If possible, describe how you are using it to make it clear for other people if you currently use as it is intended to.
 
 **How you suggest to improve it:**
 
 Describe how you propose to improve the project.
-Keep in mind improvements should be backward compatible with currently features 
+Keep in mind improvements should be backward compatible with currently features
 *if your proposal forces users to change the way they work or requires code changes, it should be proposed as a feature request*

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,23 +17,23 @@ feat: repo base files - 949
 A description of the change.
 
 <!--
-If you have access, to link to the Azure Devops Ticket type `AB#{ID}` in this PR or commit message, 
+If you have access, to link to the Azure Devops Ticket type `AB#{ID}` in this PR or commit message,
 e.g. Implements `AB#1228 - Link tickets to GitHub`
 -->
 
 #### 🤔 Why
-		
+
 Why it's needed, background context.
-		
+
 #### 🛠 How
-		
+
 More in-depth discussion of the change or implementation.
 
 #### 👀 Evidence
-		
+
 Screenshots / external resources / links / etc.
 Link to documentation updated with changes impacted in the PR.
-		 
+
 #### 🕵️ How to test
 
 Notes on how a reviewer can test the changes, e.g. how to run the tests.

--- a/azurerm/modules/azurerm-app-gateway/app_gateway.tf
+++ b/azurerm/modules/azurerm-app-gateway/app_gateway.tf
@@ -127,6 +127,14 @@ resource "azurerm_application_gateway" "network" {
     backend_http_settings_name = local.http_setting_name
   }
 
+  request_routing_rule {
+    name                       = local.request_routing_rule_name
+    rule_type                  = "Basic"
+    http_listener_name         = local.listener_name
+    backend_address_pool_name  = local.backend_address_pool_name
+    backend_http_settings_name = local.http_setting_name
+  }
+
   # ssl_policy = var.ssl_policy
   ssl_policy { # block supports the following:
     policy_type          = lookup(var.ssl_policy, "policy_type")
@@ -142,4 +150,3 @@ resource "azurerm_application_gateway" "network" {
     ]
   }
 }
-

--- a/azurerm/modules/azurerm-app-gateway/app_gateway.tf
+++ b/azurerm/modules/azurerm-app-gateway/app_gateway.tf
@@ -36,6 +36,7 @@ locals {
   listener_name                  = "${var.vnet_name}-httplstn"
   listener_name_ssl              = "${var.vnet_name}-httplstn_ssl"
   request_routing_rule_name      = "${var.vnet_name}-rqrt"
+  request_routing_rule_name_ssl  = "${var.vnet_name}-rqrt_ssl"
   redirect_configuration_name    = "${var.vnet_name}-rdrcfg"
 }
 
@@ -122,15 +123,15 @@ resource "azurerm_application_gateway" "network" {
   request_routing_rule {
     name                       = local.request_routing_rule_name
     rule_type                  = "Basic"
-    http_listener_name         = local.listener_name_ssl
+    http_listener_name         = local.listener_name
     backend_address_pool_name  = local.backend_address_pool_name
     backend_http_settings_name = local.http_setting_name
   }
 
   request_routing_rule {
-    name                       = local.request_routing_rule_name
+    name                       = local.request_routing_rule_name_ssl
     rule_type                  = "Basic"
-    http_listener_name         = local.listener_name
+    http_listener_name         = local.listener_name_ssl
     backend_address_pool_name  = local.backend_address_pool_name
     backend_http_settings_name = local.http_setting_name
   }


### PR DESCRIPTION
#### 📲 What

  * Re-adds a forwarder for Port 80 to the K8s Cluster
      - This allows people to get to the cluster via port 80 which can
	then be upgraded to https etc

#### 🤔 Why
		
Currently with the new changes and the removal of the Let's Encrypt route to a blob, we accidentally removed the HTTP listener rule.
		
#### 🛠 How
		
More in-depth discussion of the change or implementation.

#### 👀 Evidence

```
$ curl http://demo-java-api.demo2.nonprod.amidostacks.com -m 10
curl: (28) Connection timed out after 10002 milliseconds
```
