### PR TITLE
fix(gke): pass tags through as cluster labels

### DIFF
--- a/google/modules/google-gke/main.tf
+++ b/google/modules/google-gke/main.tf
@@ -31,6 +31,8 @@ module "gke_cluster" {
   # Additional Configuration
   enable_legacy_abac = var.enable_legacy_abac
   kubernetes_version = var.cluster_version
+
+  resource_labels = var.tags
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/google/modules/google-gke/main.tf
+++ b/google/modules/google-gke/main.tf
@@ -9,7 +9,7 @@
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "gke_cluster" {
-  source   = "github.com/gruntwork-io/terraform-google-gke.git//modules/gke-cluster?ref=v0.4.3"
+  source   = "github.com/gruntwork-io/terraform-google-gke.git//modules/gke-cluster?ref=v0.5.0"
   name     = var.resource_namer
   project  = var.project
   location = var.location


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Add tags to cluster labels.

<!--
If you have access, to link to the Azure Devops Ticket type `AB#{ID}` in this PR or commit message,
e.g. Implements `AB#1228 - Link tickets to GitHub`
-->

#### 🤔 Why

Tags were currently only being added as labels to the node pool and not the cluster itself.

#### 🛠 How

Using existing variable on the gke-cluster module

#### 👀 Evidence

I have deployed this successfully on the dr project

#### 🕵️ How to test

deploy cluster using this module, look at gke cluster labels

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
