### PR TITLE
feat(gcp): allow apex dns record

### DIFF
--- a/google/modules/google-k8s-server-side-app/main.tf
+++ b/google/modules/google-k8s-server-side-app/main.tf
@@ -1,6 +1,6 @@
 resource "google_dns_record_set" "default" {
   provider = google-beta
-  name = "${var.dns_record}.${lookup(var.dns_zone, "dns_name")}"
+  name = var.create_apex_record ? lookup(var.dns_zone, "dns_name") : "${var.dns_record}.${lookup(var.dns_zone, "dns_name")}"
   type = "A"
   ttl  = 300
   managed_zone = lookup(var.dns_zone, "name")

--- a/google/modules/google-k8s-server-side-app/vars.tf
+++ b/google/modules/google-k8s-server-side-app/vars.tf
@@ -90,3 +90,9 @@ variable "load_balancer_ip" {
   type = string  
 }
 
+variable "create_apex_record" {
+  description = "If true then create apex record and the value of dns_record will be ignored"
+  type = bool
+  default = false
+}
+


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Added a variable to the `google-k8s-server-side-app` module to allow creation of the app dns record as an apex record.

<!--
If you have access, to link to the Azure Devops Ticket type `AB#{ID}` in this PR or commit message,
e.g. Implements `AB#1228 - Link tickets to GitHub`
-->

#### 🤔 Why

To enable applications to be hosted at the apex record without a record name.

#### 🛠 How

Added a variable `create_apex_record` which defaults to `false`.

If `create_apex_record` = `true` then the apex record is created (the `dns_record` value will be ignored in this scenario)
if `create_apex_record` =`false` then the `dns_record` value is used as before

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR.

#### 🕵️ How to test

Notes on how a reviewer can test the changes, e.g. how to run the tests.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
