### PR TITLE
feat: Ensure that the SPN has owner rights on the resource group

### DIFF
--- a/azurerm/modules/azurerm-aks/network.tf
+++ b/azurerm/modules/azurerm-aks/network.tf
@@ -1,3 +1,8 @@
+# Configure data to access the SPN that has been used to deploy the environment
+# This will be used to set the SPN as an owner on the resource group
+data "azurerm_client_config" "spn_client" {
+}
+
 # Always create and manage an RG as part of this library
 resource "azurerm_resource_group" "default" {
   name     = var.resource_namer
@@ -8,6 +13,14 @@ resource "azurerm_resource_group" "default" {
       tags,
     ]
   }
+}
+
+# Use a role assignment to set the SPN as an owner on the resource group
+# This will allow the SPN to change role assignments of resources contained in the group
+resource "azurerm_role_assignment" "rg_owner" {
+    scope = azurerm_resource_group.default.id
+    role_definition_name = "Owner"
+    principal_id = data.azurerm_client_config.spn_client.object_id
 }
 
 locals {


### PR DESCRIPTION
# What & Why

Sets the SPN as the owner on the resource group.
This is very useful in situations where the SPN for the subscription does not have owner rights. By setting the SPN as the owner on the resource group then all operations on resources within that group are permitted. There can be issues with role assignments on resources that are created due to lack of permissions on the SPN

NB. The SPN must have "User Access Administrator" in Azure AD to allow this role assignment to be made. It is _not_ required of the SPN has owner rights.

# How

By using the `azurem_client_config` data resource Terraform can get the `object_id` of the SPN or user performing the deployment.

After the resource group has been created, the `azurerm_role_assignment` resource is used to set the `object_id` as an "Owner" on the newly created resource group.

![image](https://user-images.githubusercontent.com/791658/106290379-51858300-6242-11eb-905c-d2098142ad4e.png)

This screenshot shows that the app called "RJS" has owner rights on the resource group.

This assignment will always be made regardless of the role that the App has been given in the subscription.

There are no external variable modifications to this PR, it is just the addition of two new Terraform resources to the `network.tf` file.

# Test

A very simple test is to run the Terraform templates to stand up the resources in Azure and check that the SPN used to perform the deployment has been added as the owner of the resource group.

(I am working on some automated testing of the infrastructure in another PR)