### PR TITLE
feat: Support using an existing DNS zone in Azure

### DIFF
--- a/azurerm/modules/azurerm-aks/locals.tf
+++ b/azurerm/modules/azurerm-aks/locals.tf
@@ -1,0 +1,6 @@
+locals {
+
+    # Determine the resource group name to use for looking up the 
+    # dns zone
+    dns_resource_group = var.create_dns_zone ? var.resource_namer : coalesce(var.dns_resource_group, var.resource_namer)
+}

--- a/azurerm/modules/azurerm-aks/network.tf
+++ b/azurerm/modules/azurerm-aks/network.tf
@@ -110,7 +110,7 @@ resource "azurerm_private_dns_zone" "default" {
 resource "azurerm_private_dns_zone_virtual_network_link" "default" {
   name                  = var.resource_namer
   virtual_network_id    = azurerm_virtual_network.default.0.id
-  resource_group_name   = azurerm_resource_group.default.name
+  resource_group_name   = local.dns_resource_group
   private_dns_zone_name = var.internal_dns_zone
   depends_on = [
     azurerm_virtual_network.default,

--- a/azurerm/modules/azurerm-aks/vars.tf
+++ b/azurerm/modules/azurerm-aks/vars.tf
@@ -132,6 +132,12 @@ variable "create_dns_zone" {
   default     = true
 }
 
+variable "dns_resource_group" {
+  type = string
+  description = "RG that contains the existing DNS zones, if the zones are not being created here"
+  default = null
+}
+
 variable "internal_dns_zone" {
   description = "Internal DNS zone name - e.g. nonprod.domain.internal"
   type        = string

--- a/azurerm/modules/azurerm-app-gateway/certs.tf
+++ b/azurerm/modules/azurerm-app-gateway/certs.tf
@@ -36,7 +36,7 @@ resource "acme_certificate" "default" {
   dns_challenge {
     provider = "azure"
     config = {
-      AZURE_RESOURCE_GROUP = var.resource_group_name
+      AZURE_RESOURCE_GROUP = local.dns_resource_group
     }
   }
 }

--- a/azurerm/modules/azurerm-app-gateway/locals.tf
+++ b/azurerm/modules/azurerm-app-gateway/locals.tf
@@ -1,0 +1,6 @@
+locals {
+
+    # Determine the resource group name to use for looking up the 
+    # dns zone
+    dns_resource_group = coalesce(var.dns_resource_group, var.resource_group_name)
+}

--- a/azurerm/modules/azurerm-app-gateway/vars.tf
+++ b/azurerm/modules/azurerm-app-gateway/vars.tf
@@ -46,6 +46,12 @@ variable "resource_group_name" {
   type = string
 }
 
+variable "dns_resource_group" {
+  type = string
+  description = "RG that contains the existing DNS zones, if the zones are not being created here"
+  default = null
+}
+
 ###########################
 # CONDITIONAL SETTINGS
 ##########################


### PR DESCRIPTION
# What

This change allows the use of existing DNS zones for setting up the Azure infrastructure. This is more likely to be the scenario that Stacks is being used in, and if used will prevent the need to rerun the Terraform apply as the DNS will already been configured.

# How

During deployment of the infrastructure the user has the ability to set if the templates should set up the DNS zones that have been stated:

If set to `true` then the zones will be configured but the overall deployment will fail. To successfully complete the domain needs to have the nameservers set on it that have been provided by Azure in the created DNS zone. Only when these changes have been propagated can the deployment be run again.

If set to `false` then the zones will not be created, but the templates will still look for the zones in the current resource group, e.g. the one that is being deployed to; it is safe to assume that the zone will not exist here if it is already (potentially) being used to serve DNS.

# Why

The reason for the change is to allow a resource group to be specified that contains the zone so that the templates can reference it.

If the zone creation is set to `false` then another variable is required, called `dns_resource_group`. The default value of this variable is `null`. If this is not set then it is set to the current resource group (as is the current behaviour); this is done using conditions in the new `local.tf` file.

When the `dns_resource_group` is set to an existing resource group that contains the DNS zones, the templates will reference the named zones there.

There are two modules that require access to the DNS zones:

1. azurerm-aks
2. azurem-app-gateway

Both of them have been modified in the same way.

# Testing

The `amido/stacks-infrastructure-aks` repo will need to be modified to handle thus new feature. As this introduces new variables that have a default value it will not break the current version of that repo.

NOTE: The PR for the `amido/stacks-infrastructure-repo` will be raised once the build number of the `amido/stacks-terraform` is known. The following steps show the sort of the changes that will be made in the PR.

Clone the `amido/stacks-infrastructure-aks` repo.

Modify the `deploy/azure/infra/stacks-aks/main.tf` file. 

Comment out line 24, starting with `source` and add a new line below:

`source = "git::https://github.com/russellseymour/stacks-terraform//azurerm/modules/azurerm-aks?ref=feat/azure_existing_dns_zone"`

Add a new entry and line 28 with the following contents:

`dns_resource_group        = var.dns_resource_group`

Comment out line 58 and add new line below it:

`source = "git::https://github.com/russellseymour/stacks-terraform//azurerm/modules/azurerm-app-gateway?ref=feat/azure_existing_dns_zone"`

Add a new entry at line 68:

`dns_resource_group        = var.dns_resource_group`

Finally add the following to end of the `deploy/azure/infra/stacks-aks/vars.tf` file:

```hcl
variable "dns_resource_group" {
  type = string
  description = "RG that contains the existing DNS zones, if the zones are not being created here"
  default = null
}
```

_This is required because modules cannot take their `source` value from a variable so it has to be modified directly. Ensure that these modifications are **not** checked back into source control._

Ensure that you have a Public DNS zone and a Private DNS zone in a different resource group in Azure and that the domain for the public zone has been setup with the appropriate nameservers.

![image](https://user-images.githubusercontent.com/791658/106477215-d3beb300-649f-11eb-83dd-031dd46f7d3e.png)

In the variables file that is passed to Terraform ensure that the following items are set

 - `create_dns_zone = false`
 - `dns_resource_group = xxxxx` - where `xxxxx` is the name of the resource group containing the DNS zones.

Now run through the usual `init`, `plan` and `apply` steps for deploying the infrastructure.




