### PR TITLE
chore: remove kube dashboard config

### DIFF
--- a/azurerm/modules/azurerm-aks/aks.tf
+++ b/azurerm/modules/azurerm-aks/aks.tf
@@ -53,9 +53,6 @@ resource "azurerm_kubernetes_cluster" "default" {
     http_application_routing {
       enabled = false
     }
-    kube_dashboard {
-      enabled = true
-    }
     oms_agent {
       enabled                    = true
       log_analytics_workspace_id = azurerm_log_analytics_workspace.default.id

--- a/azurerm/modules/azurerm-aks/vars.tf
+++ b/azurerm/modules/azurerm-aks/vars.tf
@@ -190,7 +190,7 @@ variable "create_aks" {
 variable "cluster_version" {
   description = "Specify AKS cluster version - please refer to MS for latest updates on the available versions. NB: opt for stable versions where possible"
   type        = string
-  default     = "1.15.7"
+  default     = "1.19.11"
 }
 
 variable cluster_name {


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

A description of the change.

<!--
If you have access, to link to the Azure Devops Ticket type `AB#{ID}` in this PR or commit message,
e.g. Implements `AB#1228 - Link tickets to GitHub`
-->

#### 🤔 Why
The AKS dashboard add-on is set for deprecation. Use the Kubernetes resource view in the Azure portal (preview) instead.

The Kubernetes dashboard is enabled by default for clusters running a Kubernetes version less than 1.18.
The dashboard add-on will be disabled by default for all new clusters created on Kubernetes 1.18 or greater.
Starting with Kubernetes 1.19 in preview, AKS will no longer support installation of the managed kube-dashboard addon.
Existing clusters with the add-on enabled will not be impacted. Users will continue to be able to manually install the open-source dashboard as user-installed software.

https://docs.microsoft.com/en-us/azure/aks/kubernetes-dashboard#before-you-begin

#### 🛠 How

More in-depth discussion of the change or implementation.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR.

#### 🕵️ How to test

Notes on how a reviewer can test the changes, e.g. how to run the tests.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
