### PR TITLE
Fix/update gke cluster

### DIFF
--- a/google/modules/google-gke/vars.tf
+++ b/google/modules/google-gke/vars.tf
@@ -151,7 +151,7 @@ variable "enable_legacy_abac" {
 
 variable "cluster_version" {
   type    = string
-  default = "1.15.11-gke.17"
+  default = "1.19.12-gke.2101"
 }
 
 variable "is_cluster_private" {

--- a/google/modules/google-gke/vars.tf
+++ b/google/modules/google-gke/vars.tf
@@ -151,7 +151,7 @@ variable "enable_legacy_abac" {
 
 variable "cluster_version" {
   type    = string
-  default = "1.19.12-gke.2101"
+  default = "1.17.9-gke.1504"
 }
 
 variable "is_cluster_private" {


### PR DESCRIPTION
#### 📲 What

Changing the value for variable `version = var.cluster_version` - this variable sets the GKE worker node version. 

#### 🤔 Why

Our worker nodes version is way behind the cluster version. 

#### 🛠 How

Related PRs: 
https://github.com/amido/stacks-webapp-template/pull/1111/files
https://github.com/amido/stacks-pipeline-templates/pull/33

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR.

#### 🕵️ How to test

Notes on how a reviewer can test the changes, e.g. how to run the tests.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
