### PR TITLE
Added ability to disable propagation

### DIFF
--- a/azurerm/modules/azurerm-app-gateway/certs.tf
+++ b/azurerm/modules/azurerm-app-gateway/certs.tf
@@ -28,6 +28,9 @@ resource "acme_certificate" "default" {
   # subject_alternative_names = ["*.${var.dns_zone}", var.dns_zone]
   # certificate_request_pem = tls_cert_request.req.cert_request_pem
   certificate_p12_password = var.pfx_password
+
+  disable_complete_propagation = var.disable_complete_propagation
+
   dns_challenge {
     provider = "azure"
     config = {

--- a/azurerm/modules/azurerm-app-gateway/vars.tf
+++ b/azurerm/modules/azurerm-app-gateway/vars.tf
@@ -60,6 +60,11 @@ variable "create_ssl_cert" {
   default = true
 }
 
+variable "disable_complete_propagation" {
+  type    = bool
+  default = false
+}
+
 
 # ###########################
 # # NETWORK SETTINGS
@@ -128,7 +133,7 @@ variable "ssl_policy" {
   }
 }
 
-variable cert_name {
+variable "cert_name" {
   type        = string
   default     = "sample.cert.pfx"
   description = "Certificate name stored under certs/ locally, to be used for SSL appgateway"
@@ -147,7 +152,7 @@ variable "pfx_password" {
   default = "Password1"
 }
 
-variable acme_email {
+variable "acme_email" {
   type        = string
   description = "Email for Acme registration, must be a valid email"
 }


### PR DESCRIPTION
#### 📲 What

Added variable to control if complete propagation is required when creating an SSL certificate using `acme_certificate` Terraform resource.

#### 🤔 Why

Have encountered issues where propagation is not occuring in DNS zones, or at least the check for the TXT record is not passing. This seems to be incorrect as a `dig` for the TXT record shows the record.

This setting will allow Stacks to be used in more controlled environments.

#### 🛠 How

Added a new variable called `disable_complete_propagation` which is set to false (the default value for the resource) and added the parameter to the `acme_certificate` resoucre.

This variable can now be specified as part of the module parameters to control if propagation is required.

#### 👀 Evidence

Certificates are now being crreated properly.

#### 🕵️ How to test

Notes on how a reviewer can test the changes, e.g. how to run the tests.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
