### PR TITLE
fix: update enable flag type

### DIFF
--- a/aws/modules/infrastructure_modules/stacks_app/app.tf
+++ b/aws/modules/infrastructure_modules/stacks_app/app.tf
@@ -5,7 +5,7 @@ module "dynamodb_table" {
   source  = "terraform-aws-modules/dynamodb-table/aws"
   version = "~> 1.2"
 
-  count    = var.enable_dynamodb
+  count    = var.enable_dynamodb ? 1 : 0
   name     = "${var.table_name}-${var.env}"
   hash_key = var.hash_key
 

--- a/aws/modules/infrastructure_modules/stacks_app/example/main.tf
+++ b/aws/modules/infrastructure_modules/stacks_app/example/main.tf
@@ -10,7 +10,7 @@ module "server_side_app" {
 
   source = "../"
 
-  enable_dynamodb = var.enable_dynamodb ? 1 : 0
+  enable_dynamodb = var.enable_dynamodb
   table_name      = "${var.table_name}-${random_string.random.result}"
   hash_key        = var.hash_key
   attribute_name  = var.attribute_name

--- a/aws/modules/infrastructure_modules/stacks_app/variables.tf
+++ b/aws/modules/infrastructure_modules/stacks_app/variables.tf
@@ -14,9 +14,9 @@ variable "tags" {
 # Dynamo DB
 ############
 variable "enable_dynamodb" {
-  default     =  0
+  default     =  false
   description = "Whether to create dynamodb table."
-  type        = number
+  type        = bool
 }
 variable "table_name" {
   description = "The name of the table, this needs to be unique within a region."
@@ -40,14 +40,14 @@ variable "attribute_type" {
 ############
 # SQS
 ############
-variable "queue_name" {
-  description = "This is the human-readable name of the queue. If omitted, Terraform will assign a random name."
-  type        = string
-}
-
 variable "enable_queue" {
   
   default     = false
   description = "Whether to create SQS queue."
   type        = bool
 }
+variable "queue_name" {
+  description = "This is the human-readable name of the queue. If omitted, Terraform will assign a random name."
+  type        = string
+}
+


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Modified dynamodb enable flag variable type to bool, and move the conditional module creation logic to infrastructure side module library rather than calling module.
<!--
If you have access, to link to the Azure Devops Ticket type `AB#{ID}` in this PR or commit message,
e.g. Implements `AB#1228 - Link tickets to GitHub`
-->

#### 🤔 Why

To abstract the conditional module creation logic to infrastructure side module library

#### 🛠 How

More in-depth discussion of the change or implementation.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR.

#### 🕵️ How to test

Notes on how a reviewer can test the changes, e.g. how to run the tests.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
