### PR TITLE
Ability to add extra Kubernetes node pools

### DIFF
--- a/azurerm/modules/azurerm-aks/aks.tf
+++ b/azurerm/modules/azurerm-aks/aks.tf
@@ -92,6 +92,20 @@ resource "azurerm_kubernetes_cluster" "default" {
   ]
 }
 
+# Create additional node pools if they have been specified
+resource "azurerm_kubernetes_cluster_node_pool" "additional" {
+  for_each = var.aks_node_pools
+
+  name                  = each.key
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.default[0].id
+  vm_size               = each.value.vm_size
+
+  enable_auto_scaling = each.value.auto_scaling
+  min_count           = each.value.min_nodes
+  max_count           = each.value.max_nodes
+  node_count          = each.value.min_nodes
+}
+
 # perform lookup on existing ACR for stages where we don't want to create an ACR
 data "azurerm_container_registry" "acr_registry" {
   count               = var.create_acr ? 0 : 1

--- a/azurerm/modules/azurerm-aks/identity.tf
+++ b/azurerm/modules/azurerm-aks/identity.tf
@@ -48,7 +48,7 @@ resource "azurerm_key_vault" "default" {
 }
 
 resource "azurerm_user_assigned_identity" "default" {
-  count               = var.create_user_identiy ? 1 : 0
+  count               = var.create_user_identity ? 1 : 0
   location            = var.resource_group_location
   resource_group_name = azurerm_resource_group.default.name
   name                = var.resource_namer

--- a/azurerm/modules/azurerm-aks/outputs.tf
+++ b/azurerm/modules/azurerm-aks/outputs.tf
@@ -67,15 +67,15 @@ output "aks_system_identity_principal_id" {
 ### used for AAD Pod identity binding ###
 #########################################
 output "aks_default_user_identity_name" {
-  value = var.create_user_identiy ? azurerm_user_assigned_identity.default.0.name : ""
+  value = var.create_user_identity ? azurerm_user_assigned_identity.default.0.name : ""
 }
 
 output "aks_default_user_identity_id" {
-  value = var.create_user_identiy ? azurerm_user_assigned_identity.default.0.id : ""
+  value = var.create_user_identity ? azurerm_user_assigned_identity.default.0.id : ""
 }
 
 output "aks_default_user_identity_client_id" {
-  value = var.create_user_identiy ? azurerm_user_assigned_identity.default.0.client_id : ""
+  value = var.create_user_identity ? azurerm_user_assigned_identity.default.0.client_id : ""
 }
 
 output "aks_ingress_private_ip" {

--- a/azurerm/modules/azurerm-aks/vars.tf
+++ b/azurerm/modules/azurerm-aks/vars.tf
@@ -67,7 +67,7 @@ variable "resource_group_tags" {
 ###########################
 # IDENTITY SETTINGS
 ##########################
-variable "create_user_identiy" {
+variable "create_user_identity" {
   description = "Creates a User Managed Identity - which can be used subsquently with AAD pod identity extensions"
   type        = bool
   default     = true

--- a/azurerm/modules/azurerm-aks/vars.tf
+++ b/azurerm/modules/azurerm-aks/vars.tf
@@ -241,6 +241,17 @@ variable "node_count" {
   default = 0
 }
 
+variable "aks_node_pools" {
+  type = map(object({
+    vm_size      = string,
+    auto_scaling = bool,
+    min_nodes    = number,
+    max_nodes    = number
+  }))
+  description = "Additional node pools as required by the platform"
+  default     = {}
+}
+
 # DEFAULTS TO 30 if not overwritten
 variable "os_disk_size" {
   type    = number

--- a/azurerm/modules/azurerm-app-gateway/examples/appgateway-entire/main.tf
+++ b/azurerm/modules/azurerm-app-gateway/examples/appgateway-entire/main.tf
@@ -44,7 +44,7 @@ module "aks_bootstrap" {
   subnet_names            = ["k8s1"]
   aks_ingress_private_ip  = cidrhost(cidrsubnet(var.vnet_cidr.0, 4, 0), -3)
   private_cluster_enabled = false
-  create_user_identiy     = var.create_user_identiy
+  create_user_identity    = var.create_user_identity
   enable_auto_scaling     = true
   log_application_type    = var.log_application_type
   key_vault_name          = var.key_vault_name

--- a/azurerm/modules/azurerm-app-gateway/examples/appgateway-entire/outputs.tf
+++ b/azurerm/modules/azurerm-app-gateway/examples/appgateway-entire/outputs.tf
@@ -37,15 +37,15 @@ output "aks_system_identity_principal_id" {
 
 ### Identity ###
 output "aks_default_user_identity_name" {
-  value = var.create_user_identiy ? module.aks_bootstrap.aks_default_user_identity_name : ""
+  value = var.create_user_identity ? module.aks_bootstrap.aks_default_user_identity_name : ""
 }
 
 output "aks_default_user_identity_id" {
-  value = var.create_user_identiy ? module.aks_bootstrap.aks_default_user_identity_id : ""
+  value = var.create_user_identity ? module.aks_bootstrap.aks_default_user_identity_id : ""
 }
 
 output "aks_default_user_identity_client_id" {
-  value = var.create_user_identiy ? module.aks_bootstrap.aks_default_user_identity_client_id : ""
+  value = var.create_user_identity ? module.aks_bootstrap.aks_default_user_identity_client_id : ""
 }
 
 output "aks_ingress_private_ip" {

--- a/azurerm/modules/azurerm-app-gateway/examples/appgateway-entire/vars.tf
+++ b/azurerm/modules/azurerm-app-gateway/examples/appgateway-entire/vars.tf
@@ -100,7 +100,7 @@ variable "create_aksvnet" {
   default = true
 }
 
-variable "create_user_identiy" {
+variable "create_user_identity" {
   type    = bool
   default = true
 }

--- a/azurerm/modules/azurerm-cosmosdb/examples/existing-rg-cosmosdb/vars.tf
+++ b/azurerm/modules/azurerm-cosmosdb/examples/existing-rg-cosmosdb/vars.tf
@@ -103,7 +103,7 @@ variable "create_aksvnet" {
   default = true
 }
 
-variable "create_user_identiy" {
+variable "create_user_identity" {
   type    = bool
   default = true
 }


### PR DESCRIPTION
#### 📲 What

Added a new resource to the AKS module which allows additional node pools to be added to the cluster.

Corrected a spelling mistake in the variable for `create_identity`.

#### 🤔 Why

In some situations it is beneficial to have multiple node pools in a Kubernetes cluster. The reason for this is so that the control plane can be separated from the application pods that are deployed. This means that the application node pools can have a different VM size associated with them as well as having some isolation between the processed.

Having `create_identiy` as the variable name meant that things kept going wrong when the variable was spelt correctly

#### 🛠 How

Added a new resource in the module to create node pools. The has an accompanying variable which is a map of objects so that mutiple pools can be created with different settings. The default value is:

`aks_node_pools = {}`

However if a pool was to be created it can be done like so:

```
variable "aks_node_pools" {
  type = map(object({
    vm_size      = string,
    auto_scaling = bool,
    min_nodes    = number,
    max_nodes    = number
  }))
  description = "Additional node pools as required by the platform"

  default = {
    application = {
      vm_size      = "Standard_DS2_v2"
      auto_scaling = true
      min_nodes    = 3
      max_nodes    = 10
    }
  }
}
```

Renamed the incorrect variable using a global search and replace aross the repository.

#### 👀 Evidence

This has been tested using Infracost to create a plan file for an environment and determine the cost of the infrastructure.

#### 🕵️ How to test

Notes on how a reviewer can test the changes, e.g. how to run the tests.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
