### PR TITLE
Updated the AKS resource to comply with latest version of AzureRM module

### DIFF
--- a/azurerm/modules/azurerm-aks/aks.tf
+++ b/azurerm/modules/azurerm-aks/aks.tf
@@ -49,15 +49,15 @@ resource "azurerm_kubernetes_cluster" "default" {
     vnet_subnet_id      = azurerm_subnet.default.0.id
   }
 
-  addon_profile {
-    http_application_routing {
-      enabled = false
-    }
-    oms_agent {
-      enabled                    = true
-      log_analytics_workspace_id = azurerm_log_analytics_workspace.default.id
-    }
+
+  http_application_routing {
+    enabled = false
   }
+  oms_agent {
+    enabled                    = true
+    log_analytics_workspace_id = azurerm_log_analytics_workspace.default.id
+  }
+
 
   role_based_access_control {
     enabled = true

--- a/azurerm/modules/azurerm-aks/identity.tf
+++ b/azurerm/modules/azurerm-aks/identity.tf
@@ -3,7 +3,7 @@
 ##################################################
 # KEY VAULT
 resource "azurerm_key_vault" "default" {
-  count                       = 1
+  count                       = var.key_vault_count ? 1 : 0
   name                        = var.key_vault_name != "" ? var.key_vault_name : substr(var.resource_namer, 0, 24)
   location                    = var.resource_group_location
   resource_group_name         = azurerm_resource_group.default.name

--- a/azurerm/modules/azurerm-aks/outputs.tf
+++ b/azurerm/modules/azurerm-aks/outputs.tf
@@ -87,7 +87,7 @@ output "aks_ingress_public_ip" {
 }
 
 output "key_vault_name" {
-  value = azurerm_key_vault.default.0.name
+  value = var.create_key_vault ? azurerm_key_vault.default.0.name : ""
 }
 
 

--- a/azurerm/modules/azurerm-aks/vars.tf
+++ b/azurerm/modules/azurerm-aks/vars.tf
@@ -329,3 +329,9 @@ variable "key_vault_name" {
   type        = string
   default     = ""
 }
+
+variable "create_key_vault" {
+  description = "Define how many key vaults to deploy"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
#### 📲 What

Moved the `http_application_routing` and `oms_agent` to top level arguments.

Made the creation of a Key Vault optional.

#### 🤔 Why

The section `addon` has been deprecated in the `azurerm_kubernetes_cluster` resource and will be removed in version 3. This has been actioned from the deprecation notice from the provider:

![image](https://github.com/amido/stacks-terraform/assets/791658/5149f100-876c-461d-ae10-fef6091780c1)

Key vaults are now part of the `stacks-ancillary-resources` and as such do not need to be created by this module.

#### 🛠 How

Moved the `addon` arguments to the root of the resource definition.

Added a new TF variable `create_key_vault` that controls if a Key Vault is created or not. Updated the outputs so that a null string is returned if a Key vault is not created.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR.

#### 🕵️ How to test

Notes on how a reviewer can test the changes, e.g. how to run the tests.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
