### PR TITLE
fix: moves back to cloudposse after my pr is in

### DIFF
--- a/aws/modules/infrastructure_modules/vpc/vpc_flow_log.tf
+++ b/aws/modules/infrastructure_modules/vpc/vpc_flow_log.tf
@@ -170,15 +170,11 @@ module "logging_bucket" {
   }
 }
 
-# TODO: Revert back to cloudposse's version when this issue is answered:
-# https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket/issues/66
 module "vpc_flow_logs" {
   count = var.flow_log_enabled ? 1 : 0
 
-  source = "git::https://github.com/ElvenSpellmaker/terraform-aws-vpc-flow-logs-s3-bucket?ref=fix/1.3.0"
-
-  # source  = "cloudposse/vpc-flow-logs-s3-bucket/aws"
-  # version = "1.3.0"
+  source  = "cloudposse/vpc-flow-logs-s3-bucket/aws"
+  version = "1.3.1"
 
   name = "${var.vpc_name}-vpc-flow-logs"
 


### PR DESCRIPTION
#### 📲 What

Moves the VPC Flow Log module back to Cloudposse.

#### 🤔 Why

My fixes to the caller module have gone in, and so have my parent module bump PR.

#### 🛠 How

#### 👀 Evidence

#### 🕵️ How to test

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
