### PR TITLE
fix(azurerm-aks): rename enable_auto_scaling to auto_scaling_enabled …

### DIFF
--- a/azurerm/modules/azurerm-aks/aks.tf
+++ b/azurerm/modules/azurerm-aks/aks.tf
@@ -42,7 +42,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   default_node_pool {
     # TODO: variablise below:
     type                = var.nodepool_type # "VirtualMachineScaleSets" # default
-    enable_auto_scaling = var.enable_auto_scaling
+    auto_scaling_enabled = var.auto_scaling_enabled
     max_count           = var.max_nodes
     min_count           = var.min_nodes
     name                = "default"
@@ -95,7 +95,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.default[0].id
   vm_size               = each.value.vm_size
 
-  enable_auto_scaling = each.value.auto_scaling
+  auto_scaling_enabled = each.value.auto_scaling
   min_count           = each.value.min_nodes
   max_count           = each.value.max_nodes
   node_count          = each.value.min_nodes

--- a/azurerm/modules/azurerm-aks/aks.tf
+++ b/azurerm/modules/azurerm-aks/aks.tf
@@ -41,15 +41,15 @@ resource "azurerm_kubernetes_cluster" "default" {
 
   default_node_pool {
     # TODO: variablise below:
-    type                = var.nodepool_type # "VirtualMachineScaleSets" # default
+    type                 = var.nodepool_type # "VirtualMachineScaleSets" # default
     auto_scaling_enabled = var.auto_scaling_enabled
-    max_count           = var.max_nodes
-    min_count           = var.min_nodes
-    name                = "default"
-    os_disk_size_gb     = var.os_disk_size
-    vm_size             = var.vm_size
-    node_count          = var.min_nodes
-    vnet_subnet_id      = azurerm_subnet.default.0.id
+    max_count            = var.max_nodes
+    min_count            = var.min_nodes
+    name                 = "default"
+    os_disk_size_gb      = var.os_disk_size
+    vm_size              = var.vm_size
+    node_count           = var.min_nodes
+    vnet_subnet_id       = azurerm_subnet.default.0.id
   }
 
   http_application_routing_enabled  = false
@@ -96,10 +96,10 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional" {
   vm_size               = each.value.vm_size
 
   auto_scaling_enabled = each.value.auto_scaling
-  min_count           = each.value.min_nodes
-  max_count           = each.value.max_nodes
-  node_count          = each.value.min_nodes
-  vnet_subnet_id      = azurerm_subnet.default.0.id
+  min_count            = each.value.min_nodes
+  max_count            = each.value.max_nodes
+  node_count           = each.value.min_nodes
+  vnet_subnet_id       = azurerm_subnet.default.0.id
 }
 
 # perform lookup on existing ACR for stages where we don't want to create an ACR

--- a/azurerm/modules/azurerm-aks/constraints.tf
+++ b/azurerm/modules/azurerm-aks/constraints.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 1.5.1"
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0"
     }
     tls = {
       source = "hashicorp/tls"

--- a/azurerm/modules/azurerm-aks/examples/entire-infra/constraints.tf
+++ b/azurerm/modules/azurerm-aks/examples/entire-infra/constraints.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/azurerm/modules/azurerm-aks/variables.tf
+++ b/azurerm/modules/azurerm-aks/variables.tf
@@ -276,7 +276,7 @@ variable "nodepool_type" {
   default = "VirtualMachineScaleSets"
 }
 
-variable "enable_auto_scaling" {
+variable "auto_scaling_enabled" {
   type = bool
 
   default = false


### PR DESCRIPTION
## Summary

Fixes breaking changes introduced by the **azurerm provider 4.x** upgrade in the `azurerm-aks` module.

In azurerm 4.x, the deprecated `enable_*` boolean arguments were removed and replaced with `*_enabled` equivalents. This PR applies the required renames and bumps the provider version constraints accordingly.

## Changes

### `aks.tf`
- Renamed `enable_auto_scaling` to `auto_scaling_enabled` in the `default_node_pool` block of `azurerm_kubernetes_cluster`
- Renamed `enable_auto_scaling` to `auto_scaling_enabled` in `azurerm_kubernetes_cluster_node_pool`

### `variables.tf`
- Renamed variable `enable_auto_scaling` to `auto_scaling_enabled`

### `constraints.tf` (module)
- Added `version = ">= 4.0"` constraint for the `azurerm` provider

### `examples/entire-infra/constraints.tf`
- Bumped azurerm provider version constraint from `~> 3.0` to `~> 4.0`

## References

- [azurerm 4.0 Upgrade Guide](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide)