### PR TITLE
fix: eks capacity type / node type

### DIFF
--- a/aws/modules/infrastructure_modules/eks/eks_cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks_cluster.tf
@@ -17,7 +17,7 @@ module "eks_kms_key" {
 #############
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.0.9"
+  version = "~> 21.20.0"
 
   vpc_id                  = var.vpc_id
   subnet_ids              = var.vpc_private_subnets

--- a/aws/modules/infrastructure_modules/eks/locals.tf
+++ b/aws/modules/infrastructure_modules/eks/locals.tf
@@ -86,13 +86,15 @@ locals {
         min_size        = var.eks_minimum_nodes
         max_size        = var.eks_maximum_nodes
         desired_size    = var.eks_desired_nodes
-        create_iam_role = local.create_node_iam_role ? false : true                                 # As we have created the nodegroup role in this module, we do not want to create it again in the eks module
-        iam_role_arn    = local.create_node_iam_role ? aws_iam_role.node["general-${v}"].arn : null # As
+        create_iam_role = local.create_node_iam_role ? false : true
+        iam_role_arn    = local.create_node_iam_role ? aws_iam_role.node["general-${v}"].arn : null
         subnet_ids      = [var.vpc_private_subnets[k]]
 
         # `disk_size` is ignored by Bottlerocket at this time...
         # disk_size             = 50
         block_device_mappings = var.block_device_mappings
+
+        capacity_type = var.eks_node_type
 
         placement = {
           tenancy = var.eks_node_tenancy

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -29,7 +29,7 @@ variable "cluster_version" {
   type        = string
   description = "Cluster Kubernetes Version"
 
-  default = 1.32
+  default = 1.34
 }
 
 variable "cluster_endpoint_private_access" {
@@ -73,7 +73,7 @@ variable "cluster_addon_container_insights_config" {
   description = "The configuration for the Container Insights Addon 'amazon-cloudwatch-observability'. Addon version is is tied to the Kubernetes Version. See: `aws eks describe-addon-versions --kubernetes-version <version> --addon-name 'amazon-cloudwatch-observability'` for available versions"
 
   default = {
-    addon_version = "v4.3.0-eksbuild.1"
+    addon_version = "v5.3.1-eksbuild.1"
   }
 }
 
@@ -102,7 +102,7 @@ variable "eks_node_size" {
   type        = string
   description = "Configure desired no of nodes for the cluster"
 
-  default = "t3.small"
+  default = "t3.medium"
 }
 
 variable "eks_node_type" {
@@ -113,7 +113,7 @@ variable "eks_node_type" {
 
   validation {
     condition     = contains(["ON_DEMAND", "SPOT"], var.eks_node_type)
-    error_message = "Value must be one of ON_DEMAND, or SPOT."
+    error_message = "Value must be one of 'ON_DEMAND', or 'SPOT'."
   }
 }
 


### PR DESCRIPTION
#### 📲 What

Hooks up `eks_node_type` to the `capacity_type` parameter to allow `SPOT` type nodes
Bumps a few defaults in the module

#### 🤔 Why

SPOT type node_type was being ignored...

#### 🛠 How

#### 👀 Evidence

#### 🕵️ How to test

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
