### PR TITLE
fix(azurerm-adb): restore readme markdown rendering

### DIFF
--- a/azurerm/modules/azurerm-adb/README.md
+++ b/azurerm/modules/azurerm-adb/README.md
@@ -1,55 +1,41 @@
-<!-- BEGIN*TF*DOCS -->
+<!-- BEGIN_TF_DOCS -->
 
-# PROJECT\*NAME
+# PROJECT_NAME
 
-DESCRIPTION:
+## DESCRIPTION
 
----
-
-Bootstraps the infrastructure for {{SELECT*APP*TYPE }}.
+Bootstraps the infrastructure for {{SELECT_APP_TYPE }}.
 
 Will be used within the provisioned pipeline for your application depending on the options you chose.
 
-Pipeline implementation for infrastructure relies on workspaces, you can pass in whatever workspace you want from {{ SELECT*DEPLOYMENT*TYPE }} pipeline YAML.
+Pipeline implementation for infrastructure relies on workspaces, you can pass in whatever workspace you want from {{ SELECT_DEPLOYMENT_TYPE }} pipeline YAML.
 
-PREREQUISITES:
-
----
+## PREREQUISITES
 
 Azure Subscripion
 
 - SPN
   - Terraform will use this to perform the authentication for the API calls
-  - you will need the `client*id, subscription*id, client*secret, tenant*id`
+  - you will need the `client_id, subscription_id, client_secret, tenant_id`
 
 Terraform backend
 
 - resource group (can be manually created for the terraform remote state)
-
 - Blob storage container for the remote state management
 
-USAGE:
-
----
+## USAGE
 
 To activate the terraform backend for running locally we need to initialise the SPN with env vars to ensure you are running the same way as the pipeline that will ultimately be running any incremental changes.
 
 ```bash
-
 docker run -it --rm -v $(pwd):/opt/tf-lib amidostacks/ci-tf:latest /bin/bash
-
 ```
 
 ```bash
-
-export ARM*CLIENT*ID=xxxx \
-
-ARM*CLIENT*SECRET=yyyyy \
-
-ARM*SUBSCRIPTION*ID=yyyyy \
-
-ARM*TENANT*ID=yyyyy
-
+export ARM_CLIENT_ID=xxxx \
+ARM_CLIENT_SECRET=yyyyy \
+ARM_SUBSCRIPTION_ID=yyyyy \
+ARM_TENANT_ID=yyyyy
 ```
 
 alternatively you can run `az login`
@@ -57,55 +43,37 @@ alternatively you can run `az login`
 To get up and running locally you will want to create a `terraform.tfvars` file
 
 ```bash
-
-TFVAR*CONTENTS='''
-
-vnet*id                 = "amido-stacks-vnet-uks-dev"
-
-rg*name                 = "amido-stacks-rg-uks-dev"
-
-resource*group*location = "uksouth"
-
-name*company            = "amido"
-
-name*project            = "stacks"
-
-name*component          = "spa"
-
-name*environment        = "dev"
-
+TFVAR_CONTENTS='''
+vnet_id                 = "amido-stacks-vnet-uks-dev"
+rg_name                 = "amido-stacks-rg-uks-dev"
+resource_group_location = "uksouth"
+name_company            = "amido"
+name_project            = "stacks"
+name_component          = "spa"
+name_environment        = "dev"
 '''
-
-$TFVAR*CONTENTS > terraform.tfvars
-
+$TFVAR_CONTENTS > terraform.tfvars
 ```
 
 ```sh
 terraform workspace select dev || terraform workspace new dev
-
 ```
 
 terraform init -backend-config=./backend.local.tfvars
 
 ## Requirements
 
-| Name | Version |
-
-|------|---------|
-
-| <a name="requirement*terraform"></a> [terraform](#requirement*terraform) | >= 0.13 |
-
-| <a name="requirement*azurerm"></a> [azurerm](#requirement*azurerm) | ~> 3.0 |
+| Name                                                                     | Version |
+| ------------------------------------------------------------------------ | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement_azurerm)       | ~> 3.0  |
 
 ## Providers
 
-| Name | Version |
-
-|------|---------|
-
-| <a name="provider*azurerm"></a> [azurerm](#provider*azurerm) | ~> 3.0 |
-
-| <a name="provider*databricks"></a> [databricks](#provider*databricks) | n/a |
+| Name                                                                  | Version |
+| --------------------------------------------------------------------- | ------- |
+| <a name="provider_azurerm"></a> [azurerm](#provider_azurerm)          | ~> 3.0  |
+| <a name="provider_databricks"></a> [databricks](#provider_databricks) | n/a     |
 
 ## Modules
 
@@ -113,158 +81,86 @@ No modules.
 
 ## Resources
 
-| Name | Type |
-
-|------|------|
-
-| [azurerm*databricks*workspace.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks*workspace) | resource |
-
-| [azurerm\*lb.lb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb) | resource |
-
-| [azurerm*lb*backend*address*pool.lb*be*pool](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb*backend*address*pool) | resource |
-
-| [azurerm*lb*outbound*rule.lb*rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb*outbound*rule) | resource |
-
-| [azurerm*monitor*diagnostic*setting.databricks*log\*analytics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor*diagnostic*setting) | resource |
-
-| [azurerm*nat*gateway.nat](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat*gateway) | resource |
-
-| [azurerm*nat*gateway*public*ip*association.nat*ip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat*gateway*public*ip*association) | resource |
-
-| [azurerm*network*security\*group.nsg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network*security*group) | resource |
-
-| [azurerm*private*dns*cname*record.cname](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private*dns*cname*record) | resource |
-
-| [azurerm*private*dns\*zone.dns](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private*dns*zone) | resource |
-
-| [azurerm*private*dns*zone*virtual*network*link.db*dns*vnet\*link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private*dns*zone*virtual*network*link) | resource |
-
-| [azurerm*private*endpoint.databricks](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private*endpoint) | resource |
-
-| [azurerm*public*ip.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public*ip) | resource |
-
-| [azurerm*subnet.pe*subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
-
-| [azurerm*subnet.private*subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
-
-| [azurerm*subnet.public*subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
-
-| [azurerm*subnet*nat*gateway*association.private*subnet*nat](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet*nat*gateway*association) | resource |
-
-| [azurerm*subnet*nat*gateway*association.public*subnet*nat](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet*nat*gateway*association) | resource |
-
-| [azurerm*subnet*network*security*group\*association.private](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet*network*security*group*association) | resource |
-
-| [azurerm*subnet*network*security*group\*association.public](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet*network*security*group*association) | resource |
-
-| [databricks*group.project*users](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/group) | resource |
-
-| [databricks*group*member.project\*users](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/group*member) | resource |
-
-| [databricks*user.rbac*users](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/user) | resource |
-
-| [databricks*workspace*conf.this](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/workspace*conf) | resource |
-
-| [azurerm*client*config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client*config) | data source |
-
-| [azurerm*monitor*diagnostic*categories.adb*log*analytics*categories](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor*diagnostic*categories) | data source |
-
-| [azurerm*resource*group.vnet\*rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource*group) | data source |
-
-| [azurerm*subnet.pe*subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
-
-| [azurerm*subnet.private*subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
-
-| [azurerm*subnet.public*subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
-
-| [azurerm*virtual*network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual*network) | data source |
-
-| [databricks*current*user.db](https://registry.terraform.io/providers/databricks/databricks/latest/docs/data-sources/current*user) | data source |
+| Name                                                                                                                                                                                    | Type        |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [azurerm_databricks_workspace.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace)                                            | resource    |
+| [azurerm_lb.lb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb)                                                                                     | resource    |
+| [azurerm_lb_backend_address_pool.lb_be_pool](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb_backend_address_pool)                                   | resource    |
+| [azurerm_lb_outbound_rule.lb_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb_outbound_rule)                                                    | resource    |
+| [azurerm_monitor_diagnostic_setting.databricks_log_analytics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting)               | resource    |
+| [azurerm_nat_gateway.nat](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway)                                                                  | resource    |
+| [azurerm_nat_gateway_public_ip_association.nat_ip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway_public_ip_association)                   | resource    |
+| [azurerm_network_security_group.nsg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group)                                            | resource    |
+| [azurerm_private_dns_cname_record.cname](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_cname_record)                                      | resource    |
+| [azurerm_private_dns_zone.dns](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone)                                                        | resource    |
+| [azurerm_private_dns_zone_virtual_network_link.db_dns_vnet_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource    |
+| [azurerm_private_endpoint.databricks](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint)                                                 | resource    |
+| [azurerm_public_ip.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip)                                                                      | resource    |
+| [azurerm_subnet.pe_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet)                                                                      | resource    |
+| [azurerm_subnet.private_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet)                                                                 | resource    |
+| [azurerm_subnet.public_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet)                                                                  | resource    |
+| [azurerm_subnet_nat_gateway_association.private_subnet_nat](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_nat_gateway_association)             | resource    |
+| [azurerm_subnet_nat_gateway_association.public_subnet_nat](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_nat_gateway_association)              | resource    |
+| [azurerm_subnet_network_security_group_association.private](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association)  | resource    |
+| [azurerm_subnet_network_security_group_association.public](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association)   | resource    |
+| [databricks_group.project_users](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/group)                                                             | resource    |
+| [databricks_group_member.project_users](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/group_member)                                               | resource    |
+| [databricks_user.rbac_users](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/user)                                                                  | resource    |
+| [databricks_workspace_conf.this](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/workspace_conf)                                                    | resource    |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config)                                                       | data source |
+| [azurerm_monitor_diagnostic_categories.adb_log_analytics_categories](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_diagnostic_categories)  | data source |
+| [azurerm_resource_group.vnet_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group)                                                     | data source |
+| [azurerm_subnet.pe_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet)                                                                   | data source |
+| [azurerm_subnet.private_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet)                                                              | data source |
+| [azurerm_subnet.public_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet)                                                               | data source |
+| [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network)                                                      | data source |
+| [databricks_current_user.db](https://registry.terraform.io/providers/databricks/databricks/latest/docs/data-sources/current_user)                                                       | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-
-|------|-------------|------|---------|:--------:|
-
-| <a name="input*add*rbac*users"></a> [add\*rbac\*users](#input*add*rbac*users) | If set to true, the module will create databricks users and group named 'project\*users' with the specified users as members, and grant workspace and SQL access to this group. Default is false. | `bool` | `true` | no |
-
-| <a name="input*create*lb"></a> [create\*lb](#input*create*lb) | Deploy Databricks with a Load Balancer. | `bool` | `false` | no |
-
-| <a name="input*create*nat"></a> [create\*nat](#input*create*nat) | Deploy Databricks with a NAT Gateway. | `bool` | `false` | no |
-
-| <a name="input*create*pe*subnet"></a> [create\*pe\*subnet](#input*create*pe*subnet) | Set to true if you need the module to create the private endpoint subnet. | `bool` | `false` | no |
-
-| <a name="input*create*pip"></a> [create\*pip](#input*create*pip) | Create Databricks with a Public IP. | `bool` | `false` | no |
-
-| <a name="input*create*subnets"></a> [create\*subnets](#input*create*subnets) | Set to true if you need the module to create the subnets for you. | `bool` | `false` | no |
-
-| <a name="input*data*platform*log*analytics*workspace*id"></a> [data\*platform\*log\*analytics\*workspace\*id](#input*data*platform*log*analytics*workspace*id) | The Log Analytics Workspace used for the whole Data Platform. | `string` | `null` | no |
-
-| <a name="input*databricks*group*display*name"></a> [databricks\*group\*display\*name](#input*databricks*group*display*name) | If 'add\*rbac\*users' set to true then specifies databricks group display name | `string` | `"project_users"` | no |
-
-| <a name="input*databricks*sku"></a> [databricks\*sku](#input*databricks*sku) | The SKU to use for the databricks instance | `string` | `"premium"` | no |
-
-| <a name="input*databricksws*diagnostic*setting*name"></a> [databricksws\*diagnostic\*setting\*name](#input*databricksws*diagnostic*setting*name) | The Databricks workspace diagnostic setting name. | `string` | `"Databricks to Log Analytics"` | no |
-
-| <a name="input*dns*record*ttl"></a> [dns\*record\*ttl](#input*dns*record*ttl) | TTL for DNS Record. | `number` | `300` | no |
-
-| <a name="input*enable*databricksws*diagnostic"></a> [enable\*databricksws\*diagnostic](#input*enable*databricksws*diagnostic) | Whether to enable diagnostic settings for the Azure Databricks workspace | `bool` | `false` | no |
-
-| <a name="input*enable*enableDbfsFileBrowser"></a> [enable\*enableDbfsFileBrowser](#input*enable*enableDbfsFileBrowser) | Whether to enable Dbfs File browser for the Azure Databricks workspace | `bool` | `false` | no |
-
-| <a name="input*enable*private*network"></a> [enable\*private\*network](#input*enable*private*network) | Enable Secure Data Platform. | `bool` | `false` | no |
-
-| <a name="input*enable*sql*access"></a> [enable\*sql\*access](#input*enable*sql*access) | Whether to enable sql access for the databricks group | `bool` | `true` | no |
-
-| <a name="input*enable*workspace*access"></a> [enable\*workspace\*access](#input*enable*workspace*access) | Whether to enable workspace access for the databricks group | `bool` | `true` | no |
-
-| <a name="input*managed*vnet"></a> [managed\*vnet](#input*managed*vnet) | Used to determine if Databricks is created in a managed vnet configuration. | `bool` | `false` | no |
-
-| <a name="input*nat*idle*timeout"></a> [nat\*idle\*timeout](#input*nat*idle*timeout) | Idle timeout period in minutes. | `number` | `10` | no |
-
-| <a name="input*network*security*group*rules*required"></a> [network\*security\*group\*rules\*required](#input*network*security*group*rules*required) | Does the data plane (clusters) to control plane communication happen over private link endpoint only or publicly? Possible values AllRules, NoAzureDatabricksRules or NoAzureServiceRules. | `string` | `"NoAzureDatabricksRules"` | no |
-
-| <a name="input*pe*subnet*name"></a> [pe\*subnet\*name](#input*pe*subnet*name) | Name of the Subnet used to provision Private Endpoints into. | `string` | `""` | no |
-
-| <a name="input*pe*subnet*prefix"></a> [pe\*subnet\*prefix](#input*pe*subnet*prefix) | IP Address Space fo the Private Endpoints Databricks Subnet. | `list(string)` | `[]` | no |
-
-| <a name="input*private*subnet*name"></a> [private\*subnet\*name](#input*private*subnet*name) | Name of the Private Databricks Subnet. | `string` | `""` | no |
-
-| <a name="input*private*subnet*prefix"></a> [private\*subnet\*prefix](#input*private*subnet*prefix) | IP Address Space fo the Private Databricks Subnet. | `list(string)` | `[]` | no |
-
-| <a name="input*public*network*access*enabled"></a> [public\*network\*access\*enabled](#input*public*network*access*enabled) | Enables or Disabled Public Access to Databricks Workspace. | `bool` | `true` | no |
-
-| <a name="input*public*subnet*name"></a> [public\*subnet\*name](#input*public*subnet*name) | Name of the Public Databricks Subnet. | `string` | `""` | no |
-
-| <a name="input*public*subnet*prefix"></a> [public\*subnet\*prefix](#input*public*subnet*prefix) | IP Address Space fo the Public Databricks Subnet. | `list(string)` | `[]` | no |
-
-| <a name="input*rbac*databricks*users"></a> [rbac\*databricks\*users](#input*rbac*databricks*users) | If 'add\*rbac\*users' set to true then specifies RBAC Databricks users | <pre>map(object({<br> display*name = string<br> user*name = string<br> active = bool<br> }))</pre> | `null` | no |
-
-| <a name="input*resource*group*location"></a> [resource\*group\*location](#input*resource*group*location) | Location of Resource group | `string` | `"uksouth"` | no |
-
-| <a name="input*resource*group*name"></a> [resource\*group\*name](#input*resource*group*name) | Name of resource group | `string` | n/a | yes |
-
-| <a name="input*resource*namer"></a> [resource\*namer](#input*resource*namer) | User defined naming convention applied to all resources created as part of this module | `string` | n/a | yes |
-
-| <a name="input*resource*tags"></a> [resource\*tags](#input*resource*tags) | Map of tags to be applied to all resources created as part of this module | `map(string)` | `{}` | no |
-
-| <a name="input*service*endpoints"></a> [service\*endpoints](#input*service*endpoints) | List of Service Endpoints Enabled on the Subnet. | `list(string)` | <pre>[<br> "Microsoft.AzureActiveDirectory",<br> "Microsoft.KeyVault",<br> "Microsoft.ServiceBus",<br> "Microsoft.Sql",<br> "Microsoft.Storage"<br>]</pre> | no |
-
-| <a name="input*vnet*address*prefix"></a> [vnet\*address\*prefix](#input*vnet*address*prefix) | Address Prefix of the VNET. | `string` | `""` | no |
-
-| <a name="input*vnet*name"></a> [vnet\*name](#input*vnet*name) | Name of the VNET inwhich the Databricks Workspace will be provisioned. | `string` | `""` | no |
-
-| <a name="input*vnet*resource*group"></a> [vnet\*resource\*group](#input*vnet*resource*group) | The Resource Group which the VNET is provisioned. | `string` | `""` | no |
+| Name                                                                                                                                                      | Description                                                                                                                                                                                      | Type                                                                                               | Default                                                                                                                                                    | Required |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | :------: |
+| <a name="input_add_rbac_users"></a> [add_rbac_users](#input_add_rbac_users)                                                                               | If set to true, the module will create databricks users and group named 'project_users' with the specified users as members, and grant workspace and SQL access to this group. Default is false. | `bool`                                                                                             | `true`                                                                                                                                                     |    no    |
+| <a name="input_create_lb"></a> [create_lb](#input_create_lb)                                                                                              | Deploy Databricks with a Load Balancer.                                                                                                                                                          | `bool`                                                                                             | `false`                                                                                                                                                    |    no    |
+| <a name="input_create_nat"></a> [create_nat](#input_create_nat)                                                                                           | Deploy Databricks with a NAT Gateway.                                                                                                                                                            | `bool`                                                                                             | `false`                                                                                                                                                    |    no    |
+| <a name="input_create_pe_subnet"></a> [create_pe_subnet](#input_create_pe_subnet)                                                                         | Set to true if you need the module to create the private endpoint subnet.                                                                                                                        | `bool`                                                                                             | `false`                                                                                                                                                    |    no    |
+| <a name="input_create_pip"></a> [create_pip](#input_create_pip)                                                                                           | Create Databricks with a Public IP.                                                                                                                                                              | `bool`                                                                                             | `false`                                                                                                                                                    |    no    |
+| <a name="input_create_subnets"></a> [create_subnets](#input_create_subnets)                                                                               | Set to true if you need the module to create the subnets for you.                                                                                                                                | `bool`                                                                                             | `false`                                                                                                                                                    |    no    |
+| <a name="input_data_platform_log_analytics_workspace_id"></a> [data_platform_log_analytics_workspace_id](#input_data_platform_log_analytics_workspace_id) | The Log Analytics Workspace used for the whole Data Platform.                                                                                                                                    | `string`                                                                                           | `null`                                                                                                                                                     |    no    |
+| <a name="input_databricks_group_display_name"></a> [databricks_group_display_name](#input_databricks_group_display_name)                                  | If 'add_rbac_users' set to true then specifies databricks group display name                                                                                                                     | `string`                                                                                           | `"project_users"`                                                                                                                                          |    no    |
+| <a name="input_databricks_sku"></a> [databricks_sku](#input_databricks_sku)                                                                               | The SKU to use for the databricks instance                                                                                                                                                       | `string`                                                                                           | `"premium"`                                                                                                                                                |    no    |
+| <a name="input_databricksws_diagnostic_setting_name"></a> [databricksws_diagnostic_setting_name](#input_databricksws_diagnostic_setting_name)             | The Databricks workspace diagnostic setting name.                                                                                                                                                | `string`                                                                                           | `"Databricks to Log Analytics"`                                                                                                                            |    no    |
+| <a name="input_dns_record_ttl"></a> [dns_record_ttl](#input_dns_record_ttl)                                                                               | TTL for DNS Record.                                                                                                                                                                              | `number`                                                                                           | `300`                                                                                                                                                      |    no    |
+| <a name="input_enable_databricksws_diagnostic"></a> [enable_databricksws_diagnostic](#input_enable_databricksws_diagnostic)                               | Whether to enable diagnostic settings for the Azure Databricks workspace                                                                                                                         | `bool`                                                                                             | `false`                                                                                                                                                    |    no    |
+| <a name="input_enable_enableDbfsFileBrowser"></a> [enable_enableDbfsFileBrowser](#input_enable_enableDbfsFileBrowser)                                     | Whether to enable Dbfs File browser for the Azure Databricks workspace                                                                                                                           | `bool`                                                                                             | `false`                                                                                                                                                    |    no    |
+| <a name="input_enable_private_network"></a> [enable_private_network](#input_enable_private_network)                                                       | Enable Secure Data Platform.                                                                                                                                                                     | `bool`                                                                                             | `false`                                                                                                                                                    |    no    |
+| <a name="input_enable_sql_access"></a> [enable_sql_access](#input_enable_sql_access)                                                                      | Whether to enable sql access for the databricks group                                                                                                                                            | `bool`                                                                                             | `true`                                                                                                                                                     |    no    |
+| <a name="input_enable_workspace_access"></a> [enable_workspace_access](#input_enable_workspace_access)                                                    | Whether to enable workspace access for the databricks group                                                                                                                                      | `bool`                                                                                             | `true`                                                                                                                                                     |    no    |
+| <a name="input_managed_vnet"></a> [managed_vnet](#input_managed_vnet)                                                                                     | Used to determine if Databricks is created in a managed vnet configuration.                                                                                                                      | `bool`                                                                                             | `false`                                                                                                                                                    |    no    |
+| <a name="input_nat_idle_timeout"></a> [nat_idle_timeout](#input_nat_idle_timeout)                                                                         | Idle timeout period in minutes.                                                                                                                                                                  | `number`                                                                                           | `10`                                                                                                                                                       |    no    |
+| <a name="input_network_security_group_rules_required"></a> [network_security_group_rules_required](#input_network_security_group_rules_required)          | Does the data plane (clusters) to control plane communication happen over private link endpoint only or publicly? Possible values AllRules, NoAzureDatabricksRules or NoAzureServiceRules.       | `string`                                                                                           | `"NoAzureDatabricksRules"`                                                                                                                                 |    no    |
+| <a name="input_pe_subnet_name"></a> [pe_subnet_name](#input_pe_subnet_name)                                                                               | Name of the Subnet used to provision Private Endpoints into.                                                                                                                                     | `string`                                                                                           | `""`                                                                                                                                                       |    no    |
+| <a name="input_pe_subnet_prefix"></a> [pe_subnet_prefix](#input_pe_subnet_prefix)                                                                         | IP Address Space fo the Private Endpoints Databricks Subnet.                                                                                                                                     | `list(string)`                                                                                     | `[]`                                                                                                                                                       |    no    |
+| <a name="input_private_subnet_name"></a> [private_subnet_name](#input_private_subnet_name)                                                                | Name of the Private Databricks Subnet.                                                                                                                                                           | `string`                                                                                           | `""`                                                                                                                                                       |    no    |
+| <a name="input_private_subnet_prefix"></a> [private_subnet_prefix](#input_private_subnet_prefix)                                                          | IP Address Space fo the Private Databricks Subnet.                                                                                                                                               | `list(string)`                                                                                     | `[]`                                                                                                                                                       |    no    |
+| <a name="input_public_network_access_enabled"></a> [public_network_access_enabled](#input_public_network_access_enabled)                                  | Enables or Disabled Public Access to Databricks Workspace.                                                                                                                                       | `bool`                                                                                             | `true`                                                                                                                                                     |    no    |
+| <a name="input_public_subnet_name"></a> [public_subnet_name](#input_public_subnet_name)                                                                   | Name of the Public Databricks Subnet.                                                                                                                                                            | `string`                                                                                           | `""`                                                                                                                                                       |    no    |
+| <a name="input_public_subnet_prefix"></a> [public_subnet_prefix](#input_public_subnet_prefix)                                                             | IP Address Space fo the Public Databricks Subnet.                                                                                                                                                | `list(string)`                                                                                     | `[]`                                                                                                                                                       |    no    |
+| <a name="input_rbac_databricks_users"></a> [rbac_databricks_users](#input_rbac_databricks_users)                                                          | If 'add_rbac_users' set to true then specifies RBAC Databricks users                                                                                                                             | <pre>map(object({<br> display_name = string<br> user_name = string<br> active = bool<br> }))</pre> | `null`                                                                                                                                                     |    no    |
+| <a name="input_resource_group_location"></a> [resource_group_location](#input_resource_group_location)                                                    | Location of Resource group                                                                                                                                                                       | `string`                                                                                           | `"uksouth"`                                                                                                                                                |    no    |
+| <a name="input_resource_group_name"></a> [resource_group_name](#input_resource_group_name)                                                                | Name of resource group                                                                                                                                                                           | `string`                                                                                           | n/a                                                                                                                                                        |   yes    |
+| <a name="input_resource_namer"></a> [resource_namer](#input_resource_namer)                                                                               | User defined naming convention applied to all resources created as part of this module                                                                                                           | `string`                                                                                           | n/a                                                                                                                                                        |   yes    |
+| <a name="input_resource_tags"></a> [resource_tags](#input_resource_tags)                                                                                  | Map of tags to be applied to all resources created as part of this module                                                                                                                        | `map(string)`                                                                                      | `{}`                                                                                                                                                       |    no    |
+| <a name="input_service_endpoints"></a> [service_endpoints](#input_service_endpoints)                                                                      | List of Service Endpoints Enabled on the Subnet.                                                                                                                                                 | `list(string)`                                                                                     | <pre>[<br> "Microsoft.AzureActiveDirectory",<br> "Microsoft.KeyVault",<br> "Microsoft.ServiceBus",<br> "Microsoft.Sql",<br> "Microsoft.Storage"<br>]</pre> |    no    |
+| <a name="input_vnet_address_prefix"></a> [vnet_address_prefix](#input_vnet_address_prefix)                                                                | Address Prefix of the VNET.                                                                                                                                                                      | `string`                                                                                           | `""`                                                                                                                                                       |    no    |
+| <a name="input_vnet_name"></a> [vnet_name](#input_vnet_name)                                                                                              | Name of the VNET inwhich the Databricks Workspace will be provisioned.                                                                                                                           | `string`                                                                                           | `""`                                                                                                                                                       |    no    |
+| <a name="input_vnet_resource_group"></a> [vnet_resource_group](#input_vnet_resource_group)                                                                | The Resource Group which the VNET is provisioned.                                                                                                                                                | `string`                                                                                           | `""`                                                                                                                                                       |    no    |
 
 ## Outputs
 
-| Name | Description |
+| Name                                                                                      | Description              |
+| ----------------------------------------------------------------------------------------- | ------------------------ |
+| <a name="output_adb_databricks_id"></a> [adb_databricks_id](#output_adb_databricks_id)    | n/a                      |
+| <a name="output_databricks_hosturl"></a> [databricks_hosturl](#output_databricks_hosturl) | Azure Databricks HostUrl |
 
-|------|-------------|
-
-| <a name="output*adb*databricks*id"></a> [adb\*databricks\*id](#output*adb*databricks*id) | n/a |
-
-| <a name="output*databricks*hosturl"></a> [databricks\*hosturl](#output*databricks*hosturl) | Azure Databricks HostUrl |
-
-<!-- END*TF*DOCS -->
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
## Summary
- restore the Azure Databricks module README from the corrupted underscore-to-asterisk Markdown output
- convert the README content back to normal UTF-8 Markdown with valid Terraform docs markers, links, and identifiers
- satisfy markdownlint by preserving formatter-normalized list indentation and code fence languages

## Validation
- commit hooks passed, including markdownlint
- signed commit created successfully