### PR TITLE
fix: cap networks at three azs

### DIFF
--- a/aws/modules/infrastructure_modules/vpc/README.md
+++ b/aws/modules/infrastructure_modules/vpc/README.md
@@ -12,9 +12,8 @@ AWS gives different underlying zones to each account mapped to common names.
 This means each account could have a different AZ for the same Zone Name.
 AWS Recommends for consistency you map by Zone ID in order.
 
-Creates a VPC and a set of opinionated Subnets. Currently this module assumes
-no more than 3 Availability Zones and sets up all networks (except Firewall) as
-the same size.
+Creates a VPC and a set of opinionated Subnets. Currently this module assumes 3
+Availability Zones and sets up all networks (except Firewall) as the same size.
 This sets up a firewall with all domains allowed by default. This should be
 tightened up as you know which domains pods will communicate with outside of the
 network.

--- a/aws/modules/infrastructure_modules/vpc/locals.tf
+++ b/aws/modules/infrastructure_modules/vpc/locals.tf
@@ -4,11 +4,10 @@ locals {
   # there's multiple resources, so unset it here.
   tags_no_name = { for k, v in var.tags : k => v if !contains(["Name"], k) }
 
-  # Note this won't work if a region has 10+ AZs, but none do currently,
-  # besdies this module is designed for 3 AZs anyway...
-  sorted_azs = sort(data.aws_availability_zones.available.zone_ids)
+  # This module is designed for exactly 3 AZs; slice to 3 even if the region has more.
+  sorted_azs = slice(sort(data.aws_availability_zones.available.zone_ids), 0, 3)
 
-  # Generates a revese map of sorted azs to their names: e.g. { "euw1-az3" =>  }
+  # Generates a reverse map of sorted azs to their names: e.g. { "euw2-az1" => "eu-west-2a" }
   sorted_azs_map = { for az in local.sorted_azs : az => data.aws_availability_zones.available.names[index(data.aws_availability_zones.available.zone_ids, az)] }
 
   logging_bucket_name                            = "${lower(var.vpc_name)}-logging-bucket"

--- a/azurerm/modules/azurerm-aks/aks.tf
+++ b/azurerm/modules/azurerm-aks/aks.tf
@@ -78,6 +78,10 @@ resource "azurerm_kubernetes_cluster" "default" {
     #   outbound_ip_address_ids = azurerm_public_ip.default[*].id
     # }
   }
+  node_provisioning_profile {
+    mode = "Manual"
+  }
+
   # TODO: this should be changed to UserAssigned once available
   # SPN should be removed once out of preview
   identity {

--- a/azurerm/modules/azurerm-aks/dns.tf
+++ b/azurerm/modules/azurerm-aks/dns.tf
@@ -34,10 +34,9 @@ resource "azurerm_private_dns_zone" "default" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "default" {
-  name                  = var.resource_namer
-  virtual_network_id    = azurerm_virtual_network.default.0.id
-  resource_group_name   = local.dns_resource_group
-  private_dns_zone_name = var.internal_dns_zone
+  name                = var.resource_namer
+  virtual_network_id  = azurerm_virtual_network.default.0.id
+  private_dns_zone_id = azurerm_private_dns_zone.default[0].id
 
   tags = var.tags
 

--- a/azurerm/modules/azurerm-aks/identity.tf
+++ b/azurerm/modules/azurerm-aks/identity.tf
@@ -9,9 +9,8 @@ resource "azurerm_key_vault" "default" {
   resource_group_name         = azurerm_resource_group.default.name
   enabled_for_disk_encryption = true
   # current RG owner tenant ID
-  tenant_id = var.tenant_id
-  # soft_delete_enabled         = true
-  # purge_protection_enabled    = false
+  tenant_id                  = var.tenant_id
+  rbac_authorization_enabled = true
 
   sku_name = "standard"
 


### PR DESCRIPTION
# Pull Request

## 📲 What

 * Amazon has added a fourth AZ (2d) to eu-west-2 and it broke the module. This caps it at three AZs.
 * Fixes AKS tests since AzureRM 5.x

## 🤔 Why

A fourth AZ broke the module as the VPC Subnets aligned next to each other.

## 🛠 How

## 👀 Evidence

## 🕵️ How to test

## ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
